### PR TITLE
fix(TimelockPolicy): add upper bounds for delay and expirationPeriod

### DIFF
--- a/src/policies/TimelockPolicy.sol
+++ b/src/policies/TimelockPolicy.sol
@@ -68,6 +68,7 @@ contract TimelockPolicy is PolicyBase, IStatelessValidator, IStatelessValidatorW
     error ProposalNotPending();
     error OnlyAccount();
     error ProposalFromPreviousEpoch();
+    error ParametersTooLarge();
 
     /**
      * @notice Install the timelock policy
@@ -82,6 +83,10 @@ contract TimelockPolicy is PolicyBase, IStatelessValidator, IStatelessValidatorW
 
         if (delay == 0) revert InvalidDelay();
         if (expirationPeriod == 0) revert InvalidExpirationPeriod();
+        // Prevent uint48 overflow in createProposal: uint48(block.timestamp) + delay + expirationPeriod
+        if (uint256(delay) + uint256(expirationPeriod) > type(uint48).max - block.timestamp) {
+            revert ParametersTooLarge();
+        }
 
         // Increment epoch to invalidate any proposals from previous installations
         currentEpoch[id][msg.sender]++;

--- a/test/btt/Timelock.t.sol
+++ b/test/btt/Timelock.t.sol
@@ -522,18 +522,18 @@ contract TimelockTest is Test {
     }
 
     function test_GivenInitialized_WhenCallingCheckSignaturePolicy() external whenCallingCheckSignaturePolicy {
-        // it should return zero
+        // it should revert (TOB-KERNEL-20: signature validation not supported)
         vm.prank(WALLET);
-        uint256 result = timelockPolicy.checkSignaturePolicy(POLICY_ID, address(0), bytes32(0), "");
-        assertEq(result, 0, "Should return 0 when initialized");
+        vm.expectRevert("TimelockPolicy: signature validation not supported");
+        timelockPolicy.checkSignaturePolicy(POLICY_ID, address(0), bytes32(0), "");
     }
 
     function test_GivenNotInitialized_WhenCallingCheckSignaturePolicy() external whenCallingCheckSignaturePolicy {
-        // it should return one
+        // it should revert (TOB-KERNEL-20: signature validation not supported)
         address uninitWallet = address(0xcccc);
         vm.prank(uninitWallet);
-        uint256 result = timelockPolicy.checkSignaturePolicy(POLICY_ID, address(0), bytes32(0), "");
-        assertEq(result, 1, "Should return 1 when not initialized");
+        vm.expectRevert("TimelockPolicy: signature validation not supported");
+        timelockPolicy.checkSignaturePolicy(POLICY_ID, address(0), bytes32(0), "");
     }
 
     // ============ validateSignatureWithData Tests ============
@@ -543,30 +543,30 @@ contract TimelockTest is Test {
     }
 
     function test_GivenDelayAndExpirationAreNonzero() external whenCallingValidateSignatureWithData {
-        // it should return true
+        // it should revert (TOB-KERNEL-20: stateless signature validation not supported)
         bytes memory data = abi.encode(uint48(1 hours), uint48(1 days));
-        bool result = timelockPolicy.validateSignatureWithData(bytes32(0), "", data);
-        assertTrue(result, "Should return true for valid data");
+        vm.expectRevert("TimelockPolicy: stateless signature validation not supported");
+        timelockPolicy.validateSignatureWithData(bytes32(0), "", data);
     }
 
     function test_GivenDelayIsZero_WhenCallingValidateSignatureWithData()
         external
         whenCallingValidateSignatureWithData
     {
-        // it should return false
+        // it should revert (TOB-KERNEL-20: stateless signature validation not supported)
         bytes memory data = abi.encode(uint48(0), uint48(1 days));
-        bool result = timelockPolicy.validateSignatureWithData(bytes32(0), "", data);
-        assertFalse(result, "Should return false for zero delay");
+        vm.expectRevert("TimelockPolicy: stateless signature validation not supported");
+        timelockPolicy.validateSignatureWithData(bytes32(0), "", data);
     }
 
     function test_GivenExpirationIsZero_WhenCallingValidateSignatureWithData()
         external
         whenCallingValidateSignatureWithData
     {
-        // it should return false
+        // it should revert (TOB-KERNEL-20: stateless signature validation not supported)
         bytes memory data = abi.encode(uint48(1 hours), uint48(0));
-        bool result = timelockPolicy.validateSignatureWithData(bytes32(0), "", data);
-        assertFalse(result, "Should return false for zero expiration");
+        vm.expectRevert("TimelockPolicy: stateless signature validation not supported");
+        timelockPolicy.validateSignatureWithData(bytes32(0), "", data);
     }
 
     // ============ validateSignatureWithDataWithSender Tests ============
@@ -579,30 +579,30 @@ contract TimelockTest is Test {
         external
         whenCallingValidateSignatureWithDataWithSender
     {
-        // it should return true
+        // it should revert (TOB-KERNEL-20: stateless signature validation not supported)
         bytes memory data = abi.encode(uint48(1 hours), uint48(1 days));
-        bool result = timelockPolicy.validateSignatureWithDataWithSender(address(0), bytes32(0), "", data);
-        assertTrue(result, "Should return true for valid data");
+        vm.expectRevert("TimelockPolicy: stateless signature validation not supported");
+        timelockPolicy.validateSignatureWithDataWithSender(address(0), bytes32(0), "", data);
     }
 
     function test_GivenDelayIsZero_WhenCallingValidateSignatureWithDataWithSender()
         external
         whenCallingValidateSignatureWithDataWithSender
     {
-        // it should return false
+        // it should revert (TOB-KERNEL-20: stateless signature validation not supported)
         bytes memory data = abi.encode(uint48(0), uint48(1 days));
-        bool result = timelockPolicy.validateSignatureWithDataWithSender(address(0), bytes32(0), "", data);
-        assertFalse(result, "Should return false for zero delay");
+        vm.expectRevert("TimelockPolicy: stateless signature validation not supported");
+        timelockPolicy.validateSignatureWithDataWithSender(address(0), bytes32(0), "", data);
     }
 
     function test_GivenExpirationIsZero_WhenCallingValidateSignatureWithDataWithSender()
         external
         whenCallingValidateSignatureWithDataWithSender
     {
-        // it should return false
+        // it should revert (TOB-KERNEL-20: stateless signature validation not supported)
         bytes memory data = abi.encode(uint48(1 hours), uint48(0));
-        bool result = timelockPolicy.validateSignatureWithDataWithSender(address(0), bytes32(0), "", data);
-        assertFalse(result, "Should return false for zero expiration");
+        vm.expectRevert("TimelockPolicy: stateless signature validation not supported");
+        timelockPolicy.validateSignatureWithDataWithSender(address(0), bytes32(0), "", data);
     }
 
     // ============ getProposal Tests ============


### PR DESCRIPTION
## Summary

Completes **TOB-KERNEL-5** (Medium): Missing bounds checks on module installation parameters.

- Adds `ParametersTooLarge` error
- Validates `delay + expirationPeriod + block.timestamp <= type(uint48).max` in `_policyOninstall` to prevent uint48 overflow in `createProposal`
- Fixes 8 stale BTT tests that expected return values from signature methods (now revert after TOB-KERNEL-20 fix)

## Audit Reference

- **Finding:** TOB-KERNEL-5 — Missing bounds checks on module installation parameters
- **Severity:** Medium
- **Auditor:** Trail of Bits (Offchain Labs Kernel v4 Security Assessment, January 2026)

## Test plan

- [ ] Verify install reverts with `ParametersTooLarge` when delay + expirationPeriod overflows uint48
- [ ] Verify install succeeds with reasonable delay and expirationPeriod values
- [x] All 100 Timelock tests pass