### PR TITLE
fix(TimelockPolicy): correct ERC-7579 no-op detection encoding

### DIFF
--- a/src/policies/TimelockPolicy.sol
+++ b/src/policies/TimelockPolicy.sol
@@ -299,20 +299,22 @@ contract TimelockPolicy is PolicyBase, IStatelessValidator, IStatelessValidatorW
      */
     function _isNoOpERC7579Execute(bytes calldata callData) internal view returns (bool) {
         // execute(bytes32 mode, bytes calldata executionCalldata)
-        // Need: 4 (selector) + 32 (mode) + 32 (offset) + 32 (length) + data
-        if (callData.length < 68) return false;
+        // ABI layout: 4 (selector) + 32 (mode) + 32 (offset) + 32 (length) + data
+        if (callData.length < 100) return false;
 
-        // Decode the offset to executionCalldata (should be 32)
+        // Offset to executionCalldata: 2 head slots (mode + offset) = 64
         uint256 offset = uint256(bytes32(callData[36:68]));
-        if (offset != 32) return false;
+        if (offset != 64) return false;
 
         // Decode the length of executionCalldata
-        if (callData.length < 100) return false;
         uint256 execDataLength = uint256(bytes32(callData[68:100]));
 
-        // For single execution mode, executionCalldata format is:
-        // target (20 bytes) + value (32 bytes) + calldata (variable)
-        if (execDataLength < 52) return false;
+        // ERC-7579 single execution uses compact format (no length prefix):
+        // executionCalldata = abi.encodePacked(target, value, calldata)
+        // target (20 bytes) + value (32 bytes) = 52 bytes with no inner calldata
+        if (execDataLength != 52) return false;
+
+        if (callData.length < 152) return false;
 
         // Extract target address (first 20 bytes of executionCalldata)
         address target = address(bytes20(callData[100:120]));
@@ -324,19 +326,7 @@ contract TimelockPolicy is PolicyBase, IStatelessValidator, IStatelessValidatorW
         uint256 value = uint256(bytes32(callData[120:152]));
 
         // Value must be 0
-        if (value != 0) return false;
-
-        // Check calldata length (remaining bytes should indicate empty calldata)
-        // executionCalldata = target(20) + value(32) + calldataLength(32) + calldata
-        if (callData.length < 184) {
-            // If we don't have enough for calldata length field, it's malformed
-            return false;
-        }
-
-        uint256 innerCalldataLength = uint256(bytes32(callData[152:184]));
-
-        // Inner calldata must be empty
-        return innerCalldataLength == 0;
+        return value == 0;
     }
 
     /**

--- a/test/btt/Timelock.t.sol
+++ b/test/btt/Timelock.t.sol
@@ -701,15 +701,11 @@ contract TimelockTest is Test {
 
     function test_GivenTargetIsSelfAndValueIsZeroAndInnerCalldataIsEmpty() external whenDetectingERC7579ExecuteNoop {
         // it should be detected as noop
-        bytes memory callData = abi.encodePacked(
-            IERC7579Execution.execute.selector,
-            bytes32(0), // mode
-            bytes32(uint256(32)), // offset
-            bytes32(uint256(84)), // execDataLength (20+32+32)
-            bytes20(WALLET), // target = self
-            bytes32(uint256(0)), // value = 0
-            bytes32(uint256(0)) // innerCalldataLength = 0
-        );
+        // ERC-7579 compact format: abi.encodePacked(target, value) = 52 bytes
+        bytes memory executionCalldata = abi.encodePacked(bytes20(WALLET), uint256(0));
+
+        bytes memory callData =
+            abi.encodeWithSelector(IERC7579Execution.execute.selector, bytes32(0), executionCalldata);
 
         bytes memory sig = _createProposalSignature("proposal", 0);
         PackedUserOperation memory userOp = _createUserOpWithCalldata(WALLET, callData, 0, sig);
@@ -725,15 +721,11 @@ contract TimelockTest is Test {
         whenDetectingERC7579ExecuteNoop
     {
         // it should be detected as noop
-        bytes memory callData = abi.encodePacked(
-            IERC7579Execution.execute.selector,
-            bytes32(0), // mode
-            bytes32(uint256(32)), // offset
-            bytes32(uint256(84)), // execDataLength
-            bytes20(address(0)), // target = address(0)
-            bytes32(uint256(0)), // value = 0
-            bytes32(uint256(0)) // innerCalldataLength = 0
-        );
+        // ERC-7579 compact format: abi.encodePacked(target, value) = 52 bytes
+        bytes memory executionCalldata = abi.encodePacked(bytes20(address(0)), uint256(0));
+
+        bytes memory callData =
+            abi.encodeWithSelector(IERC7579Execution.execute.selector, bytes32(0), executionCalldata);
 
         bytes memory sig = _createProposalSignature("proposal", 1);
         PackedUserOperation memory userOp = _createUserOpWithCalldata(WALLET, callData, 0, sig);
@@ -756,15 +748,14 @@ contract TimelockTest is Test {
         assertEq(result, SIG_VALIDATION_FAILED, "Too short for offset should not be noop");
     }
 
-    function test_GivenOffsetIsNot32() external whenDetectingERC7579ExecuteNoop {
+    function test_GivenOffsetIsNot64() external whenDetectingERC7579ExecuteNoop {
         // it should not be detected as noop
         bytes memory callData = abi.encodePacked(
             IERC7579Execution.execute.selector,
             bytes32(0), // mode
-            bytes32(uint256(64)), // wrong offset (should be 32)
+            bytes32(uint256(32)), // wrong offset (should be 64)
             bytes32(uint256(52)), // length
-            WALLET,
-            uint256(0),
+            bytes20(WALLET),
             uint256(0)
         );
 
@@ -781,7 +772,7 @@ contract TimelockTest is Test {
         bytes memory callData = abi.encodePacked(
             IERC7579Execution.execute.selector,
             bytes32(0), // mode
-            bytes32(uint256(32)) // offset
+            bytes32(uint256(64)) // offset
             // missing length and data
         );
 
@@ -793,13 +784,13 @@ contract TimelockTest is Test {
         assertEq(result, SIG_VALIDATION_FAILED, "Too short for length should not be noop");
     }
 
-    function test_GivenExecDataLengthIsLessThan52() external whenDetectingERC7579ExecuteNoop {
-        // it should not be detected as noop
+    function test_GivenExecDataLengthIsNot52() external whenDetectingERC7579ExecuteNoop {
+        // it should not be detected as noop (length 20 != 52)
         bytes memory callData = abi.encodePacked(
             IERC7579Execution.execute.selector,
             bytes32(0), // mode
-            bytes32(uint256(32)), // offset
-            bytes32(uint256(20)) // length only 20 (need at least 52)
+            bytes32(uint256(64)), // offset
+            bytes32(uint256(20)) // length only 20 (must be exactly 52)
         );
 
         PackedUserOperation memory userOp = _createUserOpWithCalldata(WALLET, callData, 0, "");
@@ -807,12 +798,12 @@ contract TimelockTest is Test {
         vm.prank(WALLET);
         uint256 result = timelockPolicy.checkUserOpPolicy(POLICY_ID, userOp);
 
-        assertEq(result, SIG_VALIDATION_FAILED, "Exec data too short should not be noop");
+        assertEq(result, SIG_VALIDATION_FAILED, "Exec data length != 52 should not be noop");
     }
 
     function test_GivenTargetIsNotSelfOrZero() external whenDetectingERC7579ExecuteNoop {
         // it should not be detected as noop
-        bytes memory executionCalldata = abi.encodePacked(ATTACKER, uint256(0), uint256(0));
+        bytes memory executionCalldata = abi.encodePacked(bytes20(ATTACKER), uint256(0));
 
         bytes memory callData =
             abi.encodeWithSelector(IERC7579Execution.execute.selector, bytes32(0), executionCalldata);
@@ -827,7 +818,7 @@ contract TimelockTest is Test {
 
     function test_GivenValueIsNonzero() external whenDetectingERC7579ExecuteNoop {
         // it should not be detected as noop
-        bytes memory executionCalldata = abi.encodePacked(WALLET, uint256(1 ether), uint256(0));
+        bytes memory executionCalldata = abi.encodePacked(bytes20(WALLET), uint256(1 ether));
 
         bytes memory callData =
             abi.encodeWithSelector(IERC7579Execution.execute.selector, bytes32(0), executionCalldata);
@@ -840,28 +831,9 @@ contract TimelockTest is Test {
         assertEq(result, SIG_VALIDATION_FAILED, "Non-zero value should not be noop");
     }
 
-    function test_GivenCalldataIsShorterThan184Bytes() external whenDetectingERC7579ExecuteNoop {
-        // it should not be detected as noop
-        bytes memory callData = abi.encodePacked(
-            IERC7579Execution.execute.selector,
-            bytes32(0), // mode
-            bytes32(uint256(32)), // offset
-            bytes32(uint256(52)), // execDataLength (exactly 52, no room for inner calldata length)
-            WALLET, // 20 bytes
-            uint256(0) // 32 bytes = 52 total
-        );
-
-        PackedUserOperation memory userOp = _createUserOpWithCalldata(WALLET, callData, 0, "");
-
-        vm.prank(WALLET);
-        uint256 result = timelockPolicy.checkUserOpPolicy(POLICY_ID, userOp);
-
-        assertEq(result, SIG_VALIDATION_FAILED, "Too short for inner calldata length should not be noop");
-    }
-
-    function test_GivenInnerCalldataLengthIsNonzero() external whenDetectingERC7579ExecuteNoop {
-        // it should not be detected as noop
-        bytes memory executionCalldata = abi.encodePacked(WALLET, uint256(0), uint256(10));
+    function test_GivenExecDataLengthGreaterThan52() external whenDetectingERC7579ExecuteNoop {
+        // it should not be detected as noop (has inner calldata)
+        bytes memory executionCalldata = abi.encodePacked(bytes20(WALLET), uint256(0), hex"deadbeef");
 
         bytes memory callData =
             abi.encodeWithSelector(IERC7579Execution.execute.selector, bytes32(0), executionCalldata);


### PR DESCRIPTION
## Summary

Fixes **TOB-KERNEL-18** (Informational): No-op detection for ERC-7579 execute is inconsistent with actual encoding.

- **Offset fix**: `_isNoOpERC7579Execute` now checks offset `64` (2 ABI head slots) instead of `32`
- **Compact format fix**: ERC-7579 `decodeSingle` uses `abi.encodePacked(target, value, calldata)` with no explicit length prefix. No-op detection now checks `execDataLength == 52` (target 20B + value 32B, no inner calldata) instead of looking for a separate `calldataLength` word
- Updated BTT tests to use correct ABI encoding and compact execution format

## Audit Reference

- **Finding:** TOB-KERNEL-18 — No-op detection for ERC-7579 execute is inconsistent with actual encoding
- **Severity:** Informational
- **Auditor:** Trail of Bits (Offchain Labs Kernel v4 Security Assessment, January 2026)

## Test plan

- [x] Valid no-op (target=self, value=0) detected correctly
- [x] Valid no-op (target=address(0), value=0) detected correctly
- [x] Wrong offset (not 64) rejected
- [x] execDataLength != 52 rejected
- [x] execDataLength > 52 (has inner calldata) rejected
- [x] Wrong target rejected
- [x] Non-zero value rejected
- [x] Short calldata rejected